### PR TITLE
Improve live handling of TC data (quality of life).

### DIFF
--- a/Raspberry Pi/Binaries/tc.py
+++ b/Raspberry Pi/Binaries/tc.py
@@ -1,7 +1,7 @@
 import serial, time, socket, os
 
 port = '/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0'
-labels = ['lox_fill_tc', '2', '3', '4', '5']
+labels = ['1', '2', '3', '4', '5']
 log = open('/home/rocket/logs/thermocouple.csv', 'a')
 
 def millis():
@@ -30,9 +30,12 @@ while True:
     if len(data) == len(labels):
         now = millis()
         log.write(str(now) + ',' + line)
-        if now > prev + 500:
+        log.flush()
+        if now > prev + 100:
             for l, d in zip(labels, data):
                 if d != 'null':
                     bytes = (l + ' ' + l + '=' + d + ' ' + str(now * 1000000)).encode()
-                    client.sendto(bytes, addr)
+                else:
+                    bytes = (l + ' ' + l + '=-460.0 ' + str(now * 1000000)).encode()
+                client.sendto(bytes, addr)
             prev = now


### PR DESCRIPTION
Implement two (and a half) quality of life changes:
- Clean-slate TC labels (remove legacy labels).
- Handle `null` values from TC gracefully (when TC is not plugged in).
    - Send "-460", which is below absolute zero, to Grafana Live (for indicating dc of the TC).
- Push to Grafana Live 5x as fast.
    - Makes visualization of TC data live much nicer (continuous, not discrete).
- Flush to log file as often as possible.
    - Allows instantaneous raw viewing of log file.
    - Not too concerned about bottlenecking performance right now (can be re-decreased later).